### PR TITLE
fix: revert back to standard lib flag package

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ In the background, `tfautomv` will run `terraform init` and `terraform plan`.
 
 ### Ignore certain differences
 
-The `--ignore` flag allows you to ignore differences between certain resources'
+The `-ignore` flag allows you to ignore differences between certain resources'
 attributes.
 
 Rules have the following syntax:
@@ -84,7 +84,7 @@ Rules have the following syntax:
 For example:
 
 ```bash
-tfautomv --ignore=everything:random_pet:length
+tfautomv -ignore=everything:random_pet:length
 ```
 
 For nested attributes, separate parent attributes from child attributes with a
@@ -95,7 +95,7 @@ For nested attributes, separate parent attributes from child attributes with a
 <EFFECT>:<RESOURCE TYPE>:parent_list.0
 ```
 
-You can use the `--ignore` flag multiple times to specify multiple rules.
+You can use the `-ignore` flag multiple times to specify multiple rules.
 
 The following effects are available:
 
@@ -104,7 +104,7 @@ The following effects are available:
 
 ### Detailed analysis
 
-For details on which resources match and which don't, use the `--show-analysis`
+For details on which resources match and which don't, use the `-show-analysis`
 flag. Output looks like this:
 
 ![analysis](docs/analysis.png)
@@ -113,14 +113,14 @@ flag. Output looks like this:
 
 There are multiple output options supported, that you can enable with flags:
 
-- `--output=blocks` (default): appends `moved` blocks to a `moves.tf` file
-- `--output=commands`: prints `terraform state mv` commands to standard output
-- `--dry-run`: prints moves in human-readable format
+- `-output=blocks` (default): appends `moved` blocks to a `moves.tf` file
+- `-output=commands`: prints `terraform state mv` commands to standard output
+- `-dry-run`: prints moves in human-readable format
 
 ### Disabling color
 
 You can disable output formatting, including colors, bold text, etc. with the
-`--no-color` flag.
+`-no-color` flag.
 
 ## Known issues
 

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,4 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/google/go-cmp v0.5.9
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
-	github.com/spf13/pflag v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,3 @@ github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -68,7 +68,7 @@ func TestE2E(t *testing.T) {
 			name:    "ignore different attributes",
 			workdir: filepath.Join("testdata", "different-attributes"),
 			args: []string{
-				"--ignore=everything:random_pet:length",
+				"-ignore=everything:random_pet:length",
 			},
 			wantChanges: 1,
 			wantOutputInclude: []string{
@@ -79,7 +79,7 @@ func TestE2E(t *testing.T) {
 			name:    "no color",
 			workdir: filepath.Join("testdata", "same-attributes"),
 			args: []string{
-				"--no-color",
+				"-no-color",
 			},
 			wantChanges: 0,
 			wantOutputExclude: []string{

--- a/main.go
+++ b/main.go
@@ -2,24 +2,16 @@ package main
 
 import (
 	_ "embed"
+	"flag"
 	"fmt"
 	"os"
 
 	"github.com/Masterminds/semver/v3"
+
 	"github.com/padok-team/tfautomv/internal/format"
 	"github.com/padok-team/tfautomv/internal/terraform"
 	"github.com/padok-team/tfautomv/internal/tfautomv"
 	"github.com/padok-team/tfautomv/internal/tfautomv/ignore"
-	flag "github.com/spf13/pflag"
-)
-
-var (
-	dryRun       = flag.Bool("dry-run", false, "print moves instead of writing them to disk")
-	ignoreRules  = flag.StringArray("ignore", nil, "rules for ignoring certain differences")
-	noColor      = flag.Bool("no-color", false, "disable color in output")
-	outputFormat = flag.String("output", "blocks", "output format of moves (\"blocks\", \"commands\")")
-	printVersion = flag.Bool("version", false, "print version and exit")
-	showAnalysis = flag.Bool("show-analysis", false, "show detailed analysis of Terraform plan")
 )
 
 func main() {
@@ -33,13 +25,13 @@ func main() {
 var version string
 
 func run() error {
-	flag.Parse()
+	parseFlags()
 
-	if *noColor {
+	if noColor {
 		format.NoColor = true
 	}
 
-	if *printVersion {
+	if printVersion {
 		fmt.Println(version)
 		return nil
 	}
@@ -55,23 +47,23 @@ func run() error {
 		return err
 	}
 
-	switch *outputFormat {
+	switch outputFormat {
 	case "blocks":
 		if tfVer.LessThan(semver.MustParse("1.1")) {
 			return fmt.Errorf("terraform version %s does not support moved blocks", tfVer.String())
 		}
 	case "commands":
 	default:
-		return fmt.Errorf("unknown output format %q", *outputFormat)
+		return fmt.Errorf("unknown output format %q", outputFormat)
 	}
 
 	// Parse rules early on so that the user gets quick feedback in case of
 	// syntax errors.
 	var rules []ignore.Rule
-	for _, raw := range *ignoreRules {
+	for _, raw := range ignoreRules {
 		r, err := ignore.ParseRule(raw)
 		if err != nil {
-			return fmt.Errorf("invalid rule passed with --ignore flag %q: %w", raw, err)
+			return fmt.Errorf("invalid rule passed with -ignore flag %q: %w", raw, err)
 		}
 		rules = append(rules, r)
 	}
@@ -95,7 +87,7 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	if *showAnalysis {
+	if showAnalysis {
 		fmt.Fprint(os.Stderr, format.Analysis(analysis))
 	}
 
@@ -110,12 +102,12 @@ func run() error {
 	// moved blocks as a replacement, but those remain incomplete for now.
 	// Community tools like tfmigrate are also popular.
 
-	if *dryRun {
+	if dryRun {
 		fmt.Fprint(os.Stderr, format.Moves(moves))
 		return nil
 	}
 
-	switch *outputFormat {
+	switch outputFormat {
 	case "blocks":
 		err = terraform.AppendMovesToFile(moves, "moves.tf")
 		if err != nil {
@@ -128,7 +120,7 @@ func run() error {
 		fmt.Fprint(os.Stderr, format.Done(fmt.Sprintf("Wrote %d commands to standard output.", len(moves))))
 
 	default:
-		return fmt.Errorf("unknown output format %q", *outputFormat)
+		return fmt.Errorf("unknown output format %q", outputFormat)
 	}
 
 	return nil
@@ -136,4 +128,41 @@ func run() error {
 
 func logln(msg string) {
 	fmt.Fprint(os.Stderr, format.Info(msg))
+}
+
+// Flags
+var (
+	dryRun       bool
+	ignoreRules  []string
+	noColor      bool
+	outputFormat string
+	printVersion bool
+	showAnalysis bool
+)
+
+func parseFlags() {
+	flag.BoolVar(&dryRun, "dry-run", false, "print moves instead of writing them to disk")
+	flag.Var(stringSliceValue{&ignoreRules}, "ignore", "ignore differences based on a `rule`")
+	flag.BoolVar(&noColor, "no-color", false, "disable color in output")
+	flag.StringVar(&outputFormat, "output", "blocks", "output `format` of moves (\"blocks\" or \"commands\")")
+	flag.BoolVar(&showAnalysis, "show-analysis", false, "show detailed analysis of Terraform plan")
+	flag.BoolVar(&printVersion, "version", false, "print version and exit")
+
+	flag.Parse()
+}
+
+type stringSliceValue struct {
+	s *[]string
+}
+
+func (v stringSliceValue) String() string {
+	if v.s == nil || *v.s == nil {
+		return ""
+	}
+	return fmt.Sprintf("%q", *v.s)
+}
+
+func (v stringSliceValue) Set(raw string) error {
+	*v.s = append(*v.s, raw)
+	return nil
 }


### PR DESCRIPTION
Turns out that the `pflag` package logs a cryptic error when a user uses the `-h` or `--help` flag. Reverting back to the standard library's `flag` package as a consequence.

This removes an external dependency.