### PR TITLE
E2E tests with -output=commands to confirm support up to Terraform 0.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         terraform-version:
+          - 0.13.7
+          - 0.14.11
+          - 0.15.5
+          - 1.0.11
           - 1.1.9
           - 1.2.9
           - 1.3.0

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/.terraform
 **/.terraform.lock.hcl
 **/terraform.tfstate
+**/terraform.tfstate.*.backup
 
 # Compiled binaries
 bin/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ for a hands-on guided introduction de tfautomv.
 See [Usage](https://padok-team.github.io/tfautomv/usage/) for a list of
 tfautomv's features.
 
+The following versions of Terraform are supported:
+
+- `1.1.x` and above by default
+- `0.13.x` and above when using the `-output=commands` flag
+
 ## How it works
 
 See [Design](https://padok-team.github.io/tfautomv/design/) for details on how tfautomv works under the hood.

--- a/docs/content/usage/_index.md
+++ b/docs/content/usage/_index.md
@@ -12,6 +12,11 @@ analyses Terraform's plan. Based on this analysis, it identifies resources that
 have moved in your codebase but not yet in Terraform's state. For each of those
 resources, it appends a `moved` block to the `moves.tf` file.
 
+The following versions of Terraform are supported:
+
+- `1.1.x` and above by default
+- `0.13.x` and above when using the `-output=commands` flag
+
 Tfautomv is fully provider-agnostic. It works with all Terraform providers.
 
 ## How-to's


### PR DESCRIPTION
I tried to address #15, by doing the following:

- [modify end-to-end tests](https://github.com/padok-team/tfautomv/commit/8e8fc77ed0d4bd92cd55b1d5b653a36196ffe24a) to run all tests with either `-output=blocks` or `-output=commands`
- update the `.gitignore` with `tfstate.*.backup` files generated by `terraform state mv`
- skip e2e test with blocks if the terraform version does not support it
- for terraform 0.12, fallback on a manual terraform version parsing 
- add the supported version in test matrix
- update the documentation

I probably introduced some code smells, please suggest some changes if necessary!

Since it is the Hacktoberfest season, could you include the `hacktoberfest-accepted` label in the PR ? Or even add the `hacktoberfest` topic to the repo to indicate that you’re looking for Hacktoberfest PR/MRs!