### PR TITLE
Add wrapper job to CI for PR status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,20 @@
-name: Build and test
+name: Continous Integration
 
 on: push
 
 jobs:
   build-and-unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: "1.18"
       - run: make build test
 
   end-to-end-tests:
+    name: End-to-End Tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -25,9 +27,23 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: "1.18"
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false # script interferes with parsing of plan
       - run: make test-e2e
+
+  end-to-end-tests-check:
+    name: End-to-End Tests (matrix)
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [end-to-end-tests]
+    steps:
+      - run: |
+          result="${{ needs.end-to-end-tests.result }}"
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi


### PR DESCRIPTION
As per https://github.com/orgs/community/discussions/26822, we need a utility job to have our end-to-end tests be a requirement for merging any PRs.