### PR TITLE
feat: allow ignoring prefixes

### DIFF
--- a/internal/tfautomv/comparison_test.go
+++ b/internal/tfautomv/comparison_test.go
@@ -58,6 +58,7 @@ func TestCompare(t *testing.T) {
 					"f": 456,
 					"h": "goodbye",
 					"i": "{\"foo\":\"bar\"}",
+					"j": "some_string",
 				},
 			},
 			destroyed: &Resource{
@@ -71,14 +72,16 @@ func TestCompare(t *testing.T) {
 					"g": "whatever",
 					"h": 789,
 					"i": "{\n\t\"foo\": \"bar\"\n}",
+					"j": "b/some_string",
 				},
 			},
 			rules: []ignore.Rule{
 				ignore.MustParseRule("everything:my_resource:c"),
 				ignore.MustParseRule("whitespace:my_resource:i"),
+				ignore.MustParseRule("prefix:my_resource:j:b/"),
 			},
 			wantMatching:    []string{"a", "b"},
-			wantIgnored:     []string{"c", "i"},
+			wantIgnored:     []string{"c", "i", "j"},
 			wantMismatching: []string{"e", "f", "h"},
 		},
 	}

--- a/internal/tfautomv/ignore/prefix.go
+++ b/internal/tfautomv/ignore/prefix.go
@@ -1,0 +1,55 @@
+package ignore
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type prefixRule struct {
+	baseRule
+	prefix string
+}
+
+func parsePrefixRule(s string) (*prefixRule, error) {
+	parts := strings.SplitN(s, ":", 3)
+	if len(parts) != 3 {
+		return nil, errors.New("syntax error")
+	}
+
+	r := prefixRule{
+		baseRule: baseRule{
+			resourceType: parts[0],
+			attribute:    parts[1],
+		},
+		prefix: parts[2],
+	}
+
+	return &r, nil
+}
+
+func (r prefixRule) String() string {
+	return fmt.Sprintf("%s:%s:%s:%s", RuleTypePrefix, r.resourceType, r.attribute, r.prefix)
+}
+
+func (r *prefixRule) Equates(a, b interface{}) bool {
+	aVal := reflect.ValueOf(a)
+	bVal := reflect.ValueOf(b)
+
+	if aVal.Kind() != bVal.Kind() {
+		return false
+	}
+	kind := aVal.Kind()
+
+	var aStr, bStr string
+	if kind == reflect.String {
+		aStr = aVal.String()
+		bStr = bVal.String()
+	} else {
+		aStr = fmt.Sprint(a)
+		bStr = fmt.Sprint(b)
+	}
+
+	return strings.TrimPrefix(aStr, r.prefix) == strings.TrimPrefix(bStr, r.prefix)
+}

--- a/internal/tfautomv/ignore/prefix_test.go
+++ b/internal/tfautomv/ignore/prefix_test.go
@@ -1,0 +1,156 @@
+package ignore
+
+import "testing"
+
+func TestPrefixRuleAppliesTo(t *testing.T) {
+	rule := prefixRule{
+		baseRule{
+			resourceType: "my_resource",
+			attribute:    "my_attr",
+		},
+		"does-not-matter",
+	}
+
+	tt := []struct {
+		resourceType string
+		attribute    string
+		want         bool
+	}{
+		{
+			resourceType: "my_resource",
+			attribute:    "my_attr",
+			want:         true,
+		},
+		{
+			resourceType: "not_my_resource",
+			attribute:    "my_attr",
+			want:         false,
+		},
+		{
+			resourceType: "my_resource",
+			attribute:    "not_my_attr",
+			want:         false,
+		},
+		{
+			resourceType: "not_my_resource",
+			attribute:    "not_my_attr",
+			want:         false,
+		},
+	}
+
+	for _, tc := range tt {
+		actual := rule.AppliesTo(tc.resourceType, tc.attribute)
+		if actual != tc.want {
+			t.Errorf("AppliesTo(%q, %q) = %t, want %t", tc.resourceType, tc.attribute, actual, tc.want)
+		}
+	}
+}
+
+func TestPrefixRuleEquates(t *testing.T) {
+	tt := []struct {
+		valueA interface{}
+		valueB interface{}
+		prefix string
+		want   bool
+	}{
+		{
+			valueA: "foo",
+			valueB: "foo",
+			prefix: "any",
+			want:   true,
+		},
+		{
+			valueA: "foo",
+			valueB: "foo",
+			prefix: "",
+			want:   true,
+		},
+		{
+			valueA: "bc",
+			valueB: "abc",
+			prefix: "a",
+			want:   true,
+		},
+		{
+			valueA: "ac",
+			valueB: "abc",
+			prefix: "b",
+			want:   false,
+		},
+		{
+			valueA: "ab",
+			valueB: "abc",
+			prefix: "c",
+			want:   false,
+		},
+		{
+			valueA: "\tbar",
+			valueB: "foo\tbar",
+			prefix: "foo",
+			want:   true,
+		},
+		{
+			valueA: "qwertyuiop",
+			valueB: "b/qwertyuiop",
+			prefix: "b/",
+			want:   true,
+		},
+		{
+			valueA: "\tbar\n",
+			valueB: "foo\tbar",
+			prefix: "foo",
+			want:   false,
+		},
+		{
+			valueA: 123,
+			valueB: 123,
+			prefix: "any",
+			want:   true,
+		},
+		{
+			valueA: 123,
+			valueB: 456,
+			prefix: "any",
+			want:   false,
+		},
+		{
+			valueA: 123,
+			valueB: "123",
+			prefix: "any",
+			want:   false,
+		},
+		{
+			valueA: 123,
+			valueB: "foo123",
+			prefix: "foo",
+			want:   false,
+		},
+		{
+			valueA: false,
+			valueB: false,
+			prefix: "any",
+			want:   true,
+		},
+		{
+			valueA: false,
+			valueB: "false",
+			prefix: "any",
+			want:   false,
+		},
+	}
+
+	for _, tc := range tt {
+		rule := prefixRule{
+			baseRule{
+				resourceType: "my_resource",
+				attribute:    "my_attr",
+			},
+			tc.prefix,
+		}
+
+		actual := rule.Equates(tc.valueA, tc.valueB)
+		if actual != tc.want {
+			t.Errorf("Equates(%q, %q) = %t, want %t", tc.valueA, tc.valueB, actual, tc.want)
+		}
+	}
+}

--- a/internal/tfautomv/ignore/rule.go
+++ b/internal/tfautomv/ignore/rule.go
@@ -14,6 +14,9 @@ const (
 	// values.
 	RuleTypeEverything RuleType = "everything"
 
+	// RuleTypePrefix ignores a given prefix when comparing attribute values.
+	RuleTypePrefix RuleType = "prefix"
+
 	// RuleTypeWhitespace ignores differences in whitespace between two
 	// attributes' values. Whitespace is as defined by unicode.IsSpace.
 	RuleTypeWhitespace RuleType = "whitespace"
@@ -46,6 +49,8 @@ func ParseRule(s string) (Rule, error) {
 	switch ruleType {
 	case RuleTypeEverything:
 		return parseEverythingRule(parts[1])
+	case RuleTypePrefix:
+		return parsePrefixRule(parts[1])
 	case RuleTypeWhitespace:
 		return parseWhitespaceRule(parts[1])
 	default:


### PR DESCRIPTION
Add a new `prefix` rule. For example, if tfautomv's analysis displays this difference:

```
Mismatch: google_storage_bucket_iam_member.example
╷
│ + bucket = "my-bucket"
│ - bucket = "b/my-bucket"
╵
```

Then users can add this flag to ignore this difference:

```bash
tfautomv -ignore "prefix:google_storage_bucket_iam_member:bucket:b/"
```